### PR TITLE
Update Node.js from 6.10 to 8.10

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 pipeline:
   build:
-    image: node:6.10-alpine
+    image: node:8.10-alpine
     environment:
         NPM_CONFIG_LOGLEVEL:    error
     commands:

--- a/splunk-cloudwatch-logs-processor/Dockerfile
+++ b/splunk-cloudwatch-logs-processor/Dockerfile
@@ -1,4 +1,4 @@
-FROM	node:6.10-alpine
+FROM	node:8.10-alpine
 
 WORKDIR	/usr/src
 

--- a/splunk-cloudwatch-logs-processor/index.js
+++ b/splunk-cloudwatch-logs-processor/index.js
@@ -36,6 +36,7 @@ const ssmCache = {};
 
 exports.handler = (event, context, callback) => {
     console.log('Received event:', JSON.stringify(event, null, 2));
+    console.log('Received context:', JSON.stringify(context, null, 2));
 
     // CloudWatch Logs data is base64 encoded so decode here
     const payload = new Buffer(event.awslogs.data, 'base64');


### PR DESCRIPTION
*   Amazon is deprecating Node.js 6.10, so we've updated the Splunk
    lambda function to a newer, still-supported version of Node.js.

*   Add code that emits context object to logs. This module needs a
    general cleanup of logging, but now is not the time for that.